### PR TITLE
Expose `Traces.enabled?`.

### DIFF
--- a/lib/traces/provider.rb
+++ b/lib/traces/provider.rb
@@ -23,6 +23,11 @@
 require_relative 'backend'
 
 module Traces
+	# @returns [Boolean] Whether there is an active backend.
+	def self.enabled?
+		self.const_defined?(:Backend)
+	end
+	
 	# A module which contains tracing specific wrappers.
 	module Provider
 		def traces_provider
@@ -31,7 +36,7 @@ module Traces
 	end
 	
 	# Bail out if there is no backend configured.
-	if self.const_defined?(:Backend)
+	if self.enabled?
 		# Extend the specified class in order to emit traces.
 		def self.Provider(klass, &block)
 			klass.extend(Provider)


### PR DESCRIPTION
## Description

In some cases, it's useful to check whether traces are enabled or not, rather than using the `Traces::Provider` macro.

### Types of Changes

- New feature.
