### PR TITLE
Allow `Traces::Provider` to work without a block.

### DIFF
--- a/lib/traces/provider.rb
+++ b/lib/traces/provider.rb
@@ -34,7 +34,9 @@ module Traces
 			
 			klass.prepend(provider)
 			
-			provider.module_exec(&block)
+			provider.module_exec(&block) if block_given?
+			
+			return provider
 		end
 	else
 		def self.Provider(klass, &block)

--- a/test/traces/provider.rb
+++ b/test/traces/provider.rb
@@ -24,7 +24,12 @@ describe Traces::Provider do
 		span = my_class.new.make_span
 		span["key"] = "value"
 	end
-
+	
+	it "works without a block" do
+		provider = Traces::Provider(my_class)
+		expect(provider).to be_equal(my_class.traces_provider)
+	end
+	
 	it "can get current trace context" do
 		Traces::Provider(my_class) do
 			def span


### PR DESCRIPTION
Allow `Traces::Provider(class)` without a block.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
