### PR TITLE
Prefer `Traces.trace` rather than modify the current class.

### DIFF
--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -45,7 +45,7 @@ Traces::Provider(MyClass) do
 			'foo' => 'bar'
 		}
 		
-		trace('my_method', attributes: attributes) do
+		Traces.trace('my_method', attributes: attributes) do
 			super
 		end
 	end

--- a/lib/traces/backend.rb
+++ b/lib/traces/backend.rb
@@ -8,6 +8,8 @@ module Traces
 	def self.require_backend(env = ENV)
 		if backend = env['TRACES_BACKEND']
 			require(backend)
+			
+			Traces.extend(Backend::Interface)
 		end
 	end
 end

--- a/lib/traces/provider.rb
+++ b/lib/traces/provider.rb
@@ -21,6 +21,23 @@ module Traces
 		end
 	end
 	
+	module Deprecated
+		def trace(...)
+			warn "Traces::Provider.trace is deprecated. Please use Traces.trace instead."
+			Traces.trace(...)
+		end
+		
+		def trace_context
+			warn "Traces::Provider.trace_context is deprecated. Please use Traces.trace_context instead."
+			Traces.trace_context
+		end
+		
+		def trace_context=(value)
+			warn "Traces::Provider.trace_context= is deprecated. Please use Traces.trace_context= instead."
+			Traces.trace_context = value
+		end
+	end
+	
 	private_constant :Singleton
 	
 	# Bail out if there is no backend configured.
@@ -30,7 +47,7 @@ module Traces
 			klass.extend(Singleton)
 			
 			provider = klass.traces_provider
-			provider.prepend(Backend::Interface)
+			provider.prepend(Deprecated)
 			
 			klass.prepend(provider)
 			

--- a/test/traces.rb
+++ b/test/traces.rb
@@ -31,11 +31,11 @@ end
 
 Traces::Provider(MyClass) do
 	def my_method(argument)
-		trace('my_method', attributes: {argument: argument}) {super}
+		Traces.trace('my_method', attributes: {argument: argument}) {super}
 	end
 	
 	def my_method_with_result(result)
-		trace('my_method_with_result') do |span|
+		Traces.trace('my_method_with_result') do |span|
 			super.tap do |result|
 				span["result"] = result
 			end
@@ -43,13 +43,13 @@ Traces::Provider(MyClass) do
 	end
 	
 	def my_method_with_attributes(attributes)
-		trace('my_method_with_attributes', attributes: attributes) {super}
+		Traces.trace('my_method_with_attributes', attributes: attributes) {super}
 	end
 end
 
 Traces::Provider(MySubClass) do
 	def my_other_method(argument)
-		trace('my_other_method', attributes: {argument: argument}) {super}
+		Traces.trace('my_other_method', attributes: {argument: argument}) {super}
 	end
 end
 
@@ -62,7 +62,7 @@ describe Traces do
 		let(:instance) {MyClass.new}
 		
 		it "can invoke trace wrapper" do
-			expect(instance).to receive(:trace)
+			expect(Traces).to receive(:trace)
 			
 			expect(instance.my_method(10)).to be == 10
 		end
@@ -71,7 +71,7 @@ describe Traces do
 			let(:result) {"result"}
 			
 			it "can invoke trace wrapper" do
-				expect(instance).to receive(:trace)
+				expect(Traces).to receive(:trace)
 				
 				expect(instance.my_method_with_result(result)).to be == result
 			end
@@ -81,7 +81,7 @@ describe Traces do
 			let(:attributes) {{"name" => "value"}}
 			
 			it "can invoke trace wrapper" do
-				expect(instance).to receive(:trace)
+				expect(Traces).to receive(:trace)
 				
 				expect(instance.my_method_with_attributes(attributes)).to be == attributes
 			end
@@ -91,8 +91,8 @@ describe Traces do
 			let(:context) {Traces::Context.local}
 			
 			it "can create child trace context" do
-				instance.trace_context = context
-				expect(instance.trace_context).to be == context
+				Traces.trace_context = context
+				expect(Traces.trace_context).to be == context
 			end
 		end
 	end
@@ -101,7 +101,7 @@ describe Traces do
 		let(:instance) {MySubClass.new}
 		
 		it "can invoke trace wrapper" do
-			expect(instance).to receive(:trace)
+			expect(Traces).to receive(:trace)
 			
 			expect(instance.my_method(10)).to be == 20
 		end
@@ -120,7 +120,7 @@ if defined?(Traces::Backend::Test)
 			let(:attributes) {{Object.new => "value"}}
 			
 			it "fails with exception" do
-				expect(instance).to receive(:trace)
+				expect(Traces).to receive(:trace)
 				
 				expect do
 					instance.my_method_with_attributes(attributes)
@@ -138,7 +138,7 @@ if defined?(Traces::Backend::Test)
 			let(:attributes) {{"key" => value}}
 			
 			it "fails with exception" do
-				expect(instance).to receive(:trace)
+				expect(Traces).to receive(:trace)
 				
 				expect do
 					instance.my_method_with_attributes(attributes)
@@ -149,7 +149,7 @@ if defined?(Traces::Backend::Test)
 		with 'missing block' do
 			it "fails with exception" do
 				expect do
-					instance.trace('foo')
+					Traces.trace('foo')
 				end.to raise_exception(ArgumentError)
 			end		
 		end
@@ -157,7 +157,7 @@ if defined?(Traces::Backend::Test)
 		with 'invalid name' do
 			it "fails with exception" do
 				expect do
-					instance.trace(Object.new) {}
+					Traces.trace(Object.new) {}
 				end.to raise_exception(ArgumentError)
 			end		
 		end

--- a/test/traces/backend/.capture/app.rb
+++ b/test/traces/backend/.capture/app.rb
@@ -16,18 +16,18 @@ end
 
 Traces::Provider(App) do
 	def call
-		trace("my_trace", resource: "my_resource", attributes: {foo: "bar"}) do |span|
+		Traces.trace("my_trace", resource: "my_resource", attributes: {foo: "bar"}) do |span|
 			span[:foo] = "baz"
 			super
 		end
 	end
 	
 	def nested
-		trace("nested") do
-			context = self.trace_context
+		Traces.trace("nested") do
+			context = Traces.trace_context
 			
 			super do
-				self.trace_context = context
+				Traces.trace_context = context
 				
 				yield
 			end

--- a/test/traces/provider.rb
+++ b/test/traces/provider.rb
@@ -15,7 +15,7 @@ describe Traces::Provider do
 	it "can yield span" do
 		Traces::Provider(my_class) do
 			def make_span
-				trace('test.span') do |span|
+				Traces.trace('test.span') do |span|
 					return span
 				end
 			end
@@ -33,8 +33,8 @@ describe Traces::Provider do
 	it "can get current trace context" do
 		Traces::Provider(my_class) do
 			def span
-				trace('test.span') do |span|
-					return trace_context
+				Traces.trace('test.span') do |span|
+					return Traces.trace_context
 				end
 			end
 		end


### PR DESCRIPTION
It came to my attention that `trace` was a fairly generic name, and could clobber user methods. So, let's deprecate this approach and instead prefer `Traces.trace`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Breaking change.
- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
