### PR TITLE
Add required_ruby_version of ">= 3.0.0"  to Gemspec

### DIFF
--- a/traces.gemspec
+++ b/traces.gemspec
@@ -5,6 +5,7 @@ require_relative "lib/traces/version"
 Gem::Specification.new do |spec|
 	spec.name = "traces"
 	spec.version = Traces::VERSION
+	spec.required_ruby_version = ">= 3.0.0"
 	
 	spec.summary = "Application instrumentation and tracing."
 	spec.authors = ["Samuel Williams", "Felix Yan"]


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

This PR adds a `required_ruby_version` to the Gemspec because #8 introduced Ruby 2.7+ `...` syntax. I noticed that #9 is only testing against Ruby 3.0+ so I used that value. 

I noticed this change because I have a gem I am still building against Ruby 2.6 and it pulled in this incompatible dependency (I will lock the dependency in my own Gemfile, but figured it would be nice to signal compatibility through Rubygems).

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
