### PR TITLE
Add `Traces::Config` for providing user extension hooks.

### DIFF
--- a/lib/traces.rb
+++ b/lib/traces.rb
@@ -5,3 +5,7 @@
 
 require_relative 'traces/version'
 require_relative 'traces/provider'
+
+# @namespace
+module Traces
+end

--- a/lib/traces/backend.rb
+++ b/lib/traces/backend.rb
@@ -6,6 +6,7 @@
 require_relative 'config'
 
 module Traces
+	# The backend implementation is responsible for recording and reporting traces.
 	module Backend
 	end
 	

--- a/lib/traces/backend.rb
+++ b/lib/traces/backend.rb
@@ -3,27 +3,11 @@
 # Released under the MIT License.
 # Copyright, 2021-2023, by Samuel Williams.
 
-require 'console/event/failure'
+require_relative 'config'
 
 module Traces
 	module Backend
-		# Require a specific trace backend.
-		def self.require_backend(env = ENV)
-			if backend = env['TRACES_BACKEND']
-				begin
-					require(backend)
-				rescue LoadError => error
-					::Console::Event::Failure.for(error).emit(self, "Unable to load traces backend!", backend: backend, severity: :warn)
-					
-					return false
-				end
-				
-				Traces.extend(Backend::Interface)
-				
-				return true
-			end
-		end
 	end
+	
+	Config::DEFAULT.require_backend
 end
-
-Traces::Backend.require_backend

--- a/lib/traces/backend/capture.rb
+++ b/lib/traces/backend/capture.rb
@@ -7,9 +7,7 @@ require_relative '../context'
 
 require 'fiber'
 
-class Fiber
-	attr_accessor :traces_backend_context
-end
+Fiber.attr_accessor :traces_backend_context
 
 module Traces
 	module Backend
@@ -17,6 +15,11 @@ module Traces
 		module Capture
 			# A span which validates tag assignment.
 			class Span
+				# Initialize a new span.
+				# @parameter context [Context] The context in which the span is recorded.
+				# @parameter name [String] A useful name/annotation for the recorded span.
+				# @parameter resource [String] The "resource" that the span is associated with.
+				# @parameter attributes [Hash] Metadata for the recorded span.
 				def initialize(context, name, resource, attributes)
 					@context = context
 					@name = name
@@ -36,6 +39,7 @@ module Traces
 					@attributes[key] = value
 				end
 				
+				# Convert the span to a JSON representation.
 				def as_json
 					{
 						name: @name,
@@ -45,15 +49,18 @@ module Traces
 					}
 				end
 				
+				# Convert the span to a JSON string.
 				def to_json(...)
 					as_json.to_json(...)
 				end
 			end
 			
+			# All captured spans.
 			def self.spans
 				@spans ||= []
 			end
 			
+			# The capture backend interface.
 			module Interface
 				# Trace the given block of code and log the execution.
 				# @parameter name [String] A useful name/annotation for the recorded span.

--- a/lib/traces/backend/console.rb
+++ b/lib/traces/backend/console.rb
@@ -8,9 +8,7 @@ require_relative '../context'
 require 'console'
 require 'fiber'
 
-class Fiber
-	attr_accessor :traces_backend_context
-end
+Fiber.attr_accessor :traces_backend_context
 
 module Traces
 	module Backend
@@ -18,11 +16,15 @@ module Traces
 		module Console
 			# A span which validates tag assignment.
 			class Span
+				# Initialize a new span.
+				# @parameter context [Context] The context in which the span is recorded.
+				# @parameter name [String] A useful name/annotation for the recorded span.
 				def initialize(context, name)
 					@context = context
 					@name = name
 				end
 				
+				# @attribute [Context] The context in which the span is recorded.
 				attr :context
 				
 				# Assign some metadata to the span.
@@ -33,6 +35,7 @@ module Traces
 				end
 			end
 			
+			# The console backend interface.
 			module Interface
 				# Trace the given block of code and log the execution.
 				# @parameter name [String] A useful name/annotation for the recorded span.

--- a/lib/traces/backend/test.rb
+++ b/lib/traces/backend/test.rb
@@ -4,11 +4,10 @@
 # Copyright, 2021-2023, by Samuel Williams.
 
 require_relative '../context'
+
 require 'fiber'
 
-class Fiber
-	attr_accessor :traces_backend_context
-end
+Fiber.attr_accessor :traces_backend_context
 
 module Traces
 	module Backend
@@ -16,10 +15,13 @@ module Traces
 		module Test
 			# A span which validates tag assignment.
 			class Span
+				# Initialize a new span.
+				# @parameter context [Context] The context in which the span is recorded.
 				def initialize(context)
 					@context = context
 				end
 				
+				# @attribute [Context] The context in which the span is recorded.
 				attr :context
 				
 				# Assign some metadata to the span.
@@ -38,6 +40,7 @@ module Traces
 				end
 			end
 			
+			# The test backend interface.
 			module Interface
 				# Trace the given block of code and validate the interface usage.
 				# @parameter name [String] A useful name/annotation for the recorded span.

--- a/lib/traces/config.rb
+++ b/lib/traces/config.rb
@@ -4,9 +4,13 @@
 # Copyright, 2024, by Samuel Williams.
 
 module Traces
+	# Represents a configuration for the traces library.
 	class Config
 		DEFAULT_PATH = ENV.fetch("TRACES_CONFIG_DEFAULT_PATH", "config/traces.rb")
 		
+		# Load the configuration from the given path.
+		# @parameter path [String] The path to the configuration file.
+		# @returns [Config] The loaded configuration.
 		def self.load(path)
 			config = self.new
 			
@@ -17,6 +21,8 @@ module Traces
 			return config
 		end
 		
+		# Load the default configuration.
+		# @returns [Config] The default configuration.
 		def self.default
 			@default ||= self.load(DEFAULT_PATH)
 		end
@@ -25,7 +31,7 @@ module Traces
 		def prepare
 		end
 		
-		# Require a specific trace backend.
+		# Require a specific traces backend implementation.
 		def require_backend(env = ENV)
 			if backend = env['TRACES_BACKEND']
 				begin

--- a/lib/traces/config.rb
+++ b/lib/traces/config.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+module Traces
+	class Config
+		DEFAULT_PATH = ENV.fetch("TRACES_CONFIG_DEFAULT_PATH", "config/traces.rb")
+		
+		def self.load(path)
+			config = self.new
+			
+			if File.exist?(path)
+				config.instance_eval(File.read(path), path)
+			end
+			
+			return config
+		end
+		
+		def self.default
+			@default ||= self.load(DEFAULT_PATH)
+		end
+		
+		# Prepare the backend, e.g. by loading additional libraries or instrumentation.
+		def prepare
+		end
+		
+		# Require a specific trace backend.
+		def require_backend(env = ENV)
+			if backend = env['TRACES_BACKEND']
+				begin
+					if require(backend)
+						Traces.extend(Backend::Interface)
+						
+						self.prepare
+						
+						return true
+					end
+				rescue LoadError => error
+					::Console::Event::Failure.for(error).emit(self, "Unable to load traces backend!", backend: backend, severity: :warn)
+				end
+			end
+			
+			return false
+		end
+		
+		# Load the default configuration.
+		DEFAULT = self.default
+	end
+end

--- a/lib/traces/context.rb
+++ b/lib/traces/context.rb
@@ -47,6 +47,12 @@ module Traces
 		
 		SAMPLED = 0x01
 		
+		# Initialize the trace context.
+		# @parameter trace_id [String] The ID of the whole trace forest.
+		# @parameter parent_id [String] The ID of this operation as known by the caller (sometimes referred to as the span ID).
+		# @parameter flags [Integer] An 8-bit field that controls tracing flags such as sampling, trace level, etc.
+		# @parameter state [Hash] Additional vendor-specific trace identification information.
+		# @parameter remote [Boolean] Whether this context was created from a distributed trace header.
 		def initialize(trace_id, parent_id, flags, state = nil, remote: false)
 			@trace_id = trace_id
 			@parent_id = parent_id
@@ -63,13 +69,13 @@ module Traces
 		# The ID of the whole trace forest and is used to uniquely identify a distributed trace through a system. It is represented as a 16-byte array, for example, 4bf92f3577b34da6a3ce929d0e0e4736. All bytes as zero (00000000000000000000000000000000) is considered an invalid value.
 		attr :trace_id
 		
-		# The ID of this request as known by the caller (in some tracing systems, this is known as the span-id, where a span is the execution of a client request). It is represented as an 8-byte array, for example, 00f067aa0ba902b7. All bytes as zero (0000000000000000) is considered an invalid value.
+		# The ID of this operation as known by the caller (in some tracing systems, this is known as the span-id, where a span is the execution of a client operation). It is represented as an 8-byte array, for example, 00f067aa0ba902b7. All bytes as zero (0000000000000000) is considered an invalid value.
 		attr :parent_id
 		
 		# An 8-bit field that controls tracing flags such as sampling, trace level, etc. These flags are recommendations given by the caller rather than strict rules.
 		attr :flags
 		
-		# Provides additional vendor-specific trace identification information across different distributed tracing systems. Conveys information about the request’s position in multiple distributed tracing graphs.
+		# Provides additional vendor-specific trace identification information across different distributed tracing systems. Conveys information about the operation's position in multiple distributed tracing graphs.
 		attr :state
 		
 		# Denotes that the caller may have recorded trace data. When unset, the caller did not record trace data out-of-band.
@@ -87,6 +93,7 @@ module Traces
 			"00-#{@trace_id}-#{@parent_id}-#{@flags.to_s(16)}"
 		end
 		
+		# Convert the trace context to a JSON representation, including trace state.
 		def as_json
 			{
 				trace_id: @trace_id,
@@ -97,6 +104,7 @@ module Traces
 			}
 		end
 		
+		# Convert the trace context to a JSON string.
 		def to_json(...)
 			as_json.to_json(...)
 		end

--- a/lib/traces/provider.rb
+++ b/lib/traces/provider.rb
@@ -11,6 +11,7 @@ module Traces
 		Backend.const_defined?(:Interface)
 	end
 	
+	# @namespace
 	module Provider
 	end
 	

--- a/test/traces/config.rb
+++ b/test/traces/config.rb
@@ -8,13 +8,15 @@ require "json"
 
 require "sus/fixtures/console"
 
-describe Traces::Backend do
+describe Traces::Config do
+	let(:config) {subject.default}
+	
 	with ".require_backend" do
 		include_context Sus::Fixtures::Console::CapturedLogger
 		
 		it "logs a warning if backend cannot be loaded" do
 			expect(
-				subject.require_backend({"TRACES_BACKEND" => "traces/backend/missing"})
+				config.require_backend({"TRACES_BACKEND" => "traces/backend/missing"})
 			).to be == false
 			
 			expect_console.to have_logged(


### PR DESCRIPTION
Make it possible for applications to load specific tracing instrumentation at load time.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
